### PR TITLE
Protect debug statement

### DIFF
--- a/shadow.js
+++ b/shadow.js
@@ -298,7 +298,7 @@ export function getRange(root) {
   window.setTimeout(() => {
     cachedRange.delete(root);
   }, 0);
-  console.debug('getRange got', result);
+  debug && console.debug('getRange got', result);
   return result.range;
 }
 


### PR DESCRIPTION
Looks like the `debug` set to false should be also used here to prevent spamming in the console.