### PR TITLE
Fix getRange when ShadyDOM is forced

### DIFF
--- a/shadow.js
+++ b/shadow.js
@@ -246,7 +246,10 @@ function walkFromNode(node, walkForward) {
 
 const cachedRange = new Map();
 export function getRange(root) {
-  if (useDocument) {
+  if (hasShady) {
+    const s = document.getSelection();
+    return s.rangeCount ? s.getRangeAt(0) : null;
+  } else if (useDocument) {  
     // Document pierces Shadow Root for selection, so actively filter it down to the right node.
     // This is only for Firefox, which does not allow selection across Shadow Root boundaries.
     const s = document.getSelection();


### PR DESCRIPTION
I have tried to upgrade the polyfill version and got the error with `ShadyDOM` forced in Safari:

```sh
Tried to upgrade and got the following error:

```sh
[Error] TypeError: Argument 1 ('node') to Selection.containsNode must be an instance of Node
	containsNode
	getRange
	getNativeRange
	getRange
	update
	Selection
	Quill
	ready
	_enableProperties
	connectedCallback
	connectedCallback
	connectedCallback
	(anonymous function)
	appendChild
	insertBefore
	createFrom
	(anonymous function)
	forEach
	forElements
	create
	(anonymous function)
	callFn (mocha.js:1168:147)
	(anonymous function) (mocha.js:1168)
	next (mocha.js:1274:1388)
	(anonymous function) (mocha.js:1276:122)
	timeslice (mocha.js:17:244)
```

The error seems to be related to `test-fixture` somehow interfering with Shady DOM.

I didn't investigate but adding this check has fixed the issue for me.